### PR TITLE
Add instructions for installing opam and core.

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,3 +1,7 @@
+For running the tests provided, you will need `Opam` and `Core`. Consult [opam](https://opam.ocaml.org) website for instuctions on how to install for your OS. Once `opam` is installed open a terminal window and run the following command to install core:
+
+opam install core
+
 ## Running Tests
 
 Because OCaml is a compiled language you need to compile your submission and the test code before you can run the tests. Compile with


### PR DESCRIPTION
It's late but we should mention that we expect `opam` and `core` to be installed, unless that's better mentioned elsewhere.
@exercism/ocaml 