### PR TITLE
Fix bowling tests and example.

### DIFF
--- a/exercises/bowling/example.ml
+++ b/exercises/bowling/example.ml
@@ -16,4 +16,4 @@ let frame_scores =
 
 let new_game = []
 let roll pins g = pins :: g
-let score g = frame_scores g |> List.fold ~init:0 ~f:(+)
+let score g = frame_scores (List.rev g) |> List.fold ~init:0 ~f:(+)

--- a/exercises/bowling/test.ml
+++ b/exercises/bowling/test.ml
@@ -2,7 +2,7 @@ open Core.Std
 open OUnit2
 module B = Bowling
 
-let (>>) = Fn.compose
+let (>>) = Fn.flip Fn.compose
 
 let assert_score e g _test_context =
   assert_equal ~printer:Int.to_string e (B.new_game |> g |> B.score)


### PR DESCRIPTION
Fn.compose has type `('b -> 'c) -> ('a -> 'b) -> 'a -> 'c` which means that test code like this `roll_spare >> roll 3` reads not as to roll spare and then score 3 pins, but to score 3 pins and then roll spare.

Tests worked for example implementation, because it was checking rolls from last to first, i.e. in reverse.