### PR TITLE
Add traverse option in build command

### DIFF
--- a/exercises/anagram/Makefile
+++ b/exercises/anagram/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/beer-song/Makefile
+++ b/exercises/beer-song/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/bob/Makefile
+++ b/exercises/bob/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/bowling/Makefile
+++ b/exercises/bowling/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/custom-set/Makefile
+++ b/exercises/custom-set/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/grade-school/Makefile
+++ b/exercises/grade-school/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/hamming/Makefile
+++ b/exercises/hamming/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/hangman/Makefile
+++ b/exercises/hangman/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -use-ocamlfind -pkg oUnit -quiet -pkg react test.native
+	@corebuild -r -use-ocamlfind -pkg oUnit -quiet -pkg react test.native
 
 clean:
 	rm -rf _build

--- a/exercises/hexadecimal/Makefile
+++ b/exercises/hexadecimal/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/leap/Makefile
+++ b/exercises/leap/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/list-ops/Makefile
+++ b/exercises/list-ops/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/luhn/Makefile
+++ b/exercises/luhn/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/minesweeper/Makefile
+++ b/exercises/minesweeper/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/nucleotide-count/Makefile
+++ b/exercises/nucleotide-count/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/phone-number/Makefile
+++ b/exercises/phone-number/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/prime-factors/Makefile
+++ b/exercises/prime-factors/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/rna-transcription/Makefile
+++ b/exercises/rna-transcription/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/space-age/Makefile
+++ b/exercises/space-age/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/word-count/Makefile
+++ b/exercises/word-count/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/zipper/Makefile
+++ b/exercises/zipper/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -quiet -pkg oUnit test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build


### PR DESCRIPTION
The traverse directory option (-r) is added to the build command as to silence a warning that could potentially put off user from following the OCaml track.

Fixes #51