### PR TITLE
move attribution for the ocaml logo here

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 The MIT License (MIT)
 
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+
+### OCaml icon
+The [OCaml](https://ocaml.org) logo is released under the [Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/) license.


### PR DESCRIPTION
a step in fixing https://github.com/exercism/exercism.io/issues/3112.