### PR TITLE
Update Travis build to use Ocaml version 4.03.0

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -2,7 +2,7 @@
 OPAM_DEPENDS="ocamlfind core ounit react"
 
 case "$OCAML_VERSION,$OPAM_VERSION" in
-    4.02.3,1.2.2) ppa=avsm/ocaml42+opam12 ;;
+    4.03.0,1.2.2) ppa=avsm/ocaml42+opam12 ;;
     *) echo Unknown $OCAML_VERSION,$OPAM_VERSION; exit 1 ;;
 esac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ script:
   - bin/configlet .
 
 env:
-  - OCAML_VERSION=4.02.3 OPAM_VERSION=1.2.2
+  - OCAML_VERSION=4.03.0 OPAM_VERSION=1.2.2


### PR DESCRIPTION
Update to the latest which is 4.03.0. Current version of 4.02.3 is over 1 year old - I'd expect most new users would be working off the latest version.