### PR TITLE
Unignore tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # assignments
 ASSIGNMENT ?= ""
-IGNOREDIRS := "^(\.git|bin|docs|lib|exercises|prime-factors|word-count|zipper)$$"
-ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort | grep -Ev $(IGNOREDIRS))
+ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort)
 
 default: test
 

--- a/exercises/word-count/example.ml
+++ b/exercises/word-count/example.ml
@@ -7,7 +7,7 @@ open Core.Std
  * This uses manual string slicing to avoid depending on any regex package
  * and because regexes are best avoided for simple tasks.
 *)
-let (words : string -> string list) s =
+let words (s: string): string list =
   let f i ((osi, l) as acc) c = match (osi, c) with
     | (None, c) when Char.is_alphanum c          -> (Some i, l)
     | (Some si, c) when not (Char.is_alphanum c) -> (None, String.slice s si i :: l)

--- a/exercises/zipper/HINT.md
+++ b/exercises/zipper/HINT.md
@@ -1,7 +1,6 @@
-## with sexp
-The file `tree.ml` use the following expression: `with sexp`. Using this
-expression is [deprecated](https://github.com/janestreet/pa_sexp_conv). The
-alternative is using `[@@deriving sexp]`.
+## [@@deriving sexp]
+The file `tree.ml` uses the following expression: `[@@deriving sexp]`. This
+is described in (https://github.com/janestreet/pa_sexp_conv).
 
-Although at the moment `with sexp` can still be used, in could be removed in the
-future. So make sure to use the newer form in your own code.
+If you have read the Real World OCaml book (http://realworldocaml.org), note
+that the deriving attribute replaces the `with sexp` syntax described there.

--- a/exercises/zipper/example.ml
+++ b/exercises/zipper/example.ml
@@ -4,11 +4,11 @@ type 'a trail =
   | L of 'a * 'a Tree.t option * 'a trail (* Left path taken *)
   | R of 'a * 'a Tree.t option * 'a trail (* Right path taken *)
   | T                                     (* Top level (root) *)
-with sexp
+[@@deriving sexp]
 
 type 'a t = { value: 'a;
               left: 'a Tree.t option;
-              right: 'a Tree.t option; trail: 'a trail } with sexp
+              right: 'a Tree.t option; trail: 'a trail } [@@deriving sexp]
 
 let rec equal veq a b =
   veq a.value b.value &&

--- a/exercises/zipper/tree.ml
+++ b/exercises/zipper/tree.ml
@@ -1,7 +1,7 @@
 open Core.Std
 
 type 'a t = { value : 'a; left : 'a t option; right : 'a t option }
-with sexp
+  [@@deriving sexp]
 
 let rec equal veq a b =
   veq a.value b.value &&


### PR DESCRIPTION
Build all exercises in the Travis build.

Note that the build failed in Zipper using the ```with sexp``` syntax - so I moved to the newer ```[@@deriving sexp]``` and updated the hints markdown.