### PR TITLE
Add all your base exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -62,11 +62,6 @@
       "topics": []
     },
     {
-      "slug": "hexadecimal",
-      "difficulty": 3,
-      "topics": []
-    },
-    {
       "slug": "anagram",
       "difficulty": 3,
       "topics": []
@@ -75,6 +70,11 @@
       "slug": "space-age",
       "difficulty": 3,
       "topics": []
+    },
+    {
+      "slug": "all-your-base",
+      "difficulty": 4,
+      "topics": ["Mathematics"]
     },
     {
       "slug": "bracket-push",
@@ -158,6 +158,7 @@
     }
   ],
   "deprecated": [
+    "hexadecimal",
     "point-mutations"
   ],
   "ignored": [

--- a/exercises/all-your-base/.merlin
+++ b/exercises/all-your-base/.merlin
@@ -1,0 +1,5 @@
+PKG findlib
+PKG core
+PKG ounit
+S *
+B *

--- a/exercises/all-your-base/Makefile
+++ b/exercises/all-your-base/Makefile
@@ -1,0 +1,11 @@
+test: test.native
+	@./test.native
+
+test.native: *.ml *.mli
+	@corebuild -r -quiet -pkg oUnit test.native
+
+clean:
+	rm -rf _build
+	rm -f test.native
+
+.PHONY: clean

--- a/exercises/all-your-base/all_your_base.mli
+++ b/exercises/all-your-base/all_your_base.mli
@@ -1,0 +1,5 @@
+open Core.Std
+
+type base = int
+
+val convert_bases : from: base -> digits: int list -> target: base -> (int list) option

--- a/exercises/all-your-base/example.ml
+++ b/exercises/all-your-base/example.ml
@@ -1,0 +1,20 @@
+open Core.Std
+
+type base = int
+
+let rec to_digits (b: base) (acc: int list) = function
+  | 0 -> acc
+  | n -> to_digits b (n % b :: acc) (n / b)
+
+let convert_bases ~from ~digits ~target =
+  if from <= 1 || target <= 1 || List.is_empty digits
+  then None
+  else
+    let open Option.Monad_infix in
+    let digits = List.fold_left digits ~init:(Some 0) ~f:(fun acc d ->
+        if d < 0 || d >= from
+        then None
+        else acc >>= (fun acc -> Some (acc * from + d))
+      ) in
+    Option.map digits ~f:(to_digits target [])
+    |> Option.map ~f:(fun xs -> if List.is_empty xs then [0] else xs)

--- a/exercises/all-your-base/test.ml
+++ b/exercises/all-your-base/test.ml
@@ -1,0 +1,58 @@
+open Core.Std
+open OUnit2
+open All_your_base
+
+let option_printer = function
+  | None -> "None"
+  | Some xs -> "Some [" ^ String.concat ~sep:";" (List.map xs ~f:Int.to_string) ^ "]"
+
+let ae exp got _test_ctxt =
+  assert_equal exp got ~printer:option_printer
+
+let tests = [
+  "single bit one to decimal" >::
+    ae (Some [1]) (convert_bases ~from:2 ~digits:[1] ~target:10);
+  "binary to single decimal" >::
+    ae (Some [5]) (convert_bases ~from:2 ~digits:[1; 0; 1] ~target:10);
+  "single decimal to binary" >::
+    ae (Some [1; 0; 1]) (convert_bases ~from:10 ~digits:[5] ~target:2);
+  "binary to multiple decimal" >::
+    ae (Some [4; 2]) (convert_bases ~from:2 ~digits:[1; 0; 1; 0; 1; 0] ~target:10);
+  "decimal to binary" >::
+    ae (Some [1; 0; 1; 0; 1; 0]) (convert_bases ~from:10 ~digits:[4; 2] ~target:2);
+  "trinary to hexadecimal" >::
+    ae (Some [2; 10]) (convert_bases ~from:3 ~digits:[1; 1; 2; 0] ~target:16);
+  "hexadecimal to trinary" >::
+    ae (Some [1; 1; 2; 0]) (convert_bases ~from:16 ~digits:[2; 10] ~target:3);
+  "15-bit integer" >::
+    ae (Some [6; 10; 45]) (convert_bases ~from:97 ~digits:[3; 46; 60] ~target:73);
+  "empty list" >::
+    ae None (convert_bases ~from:2 ~digits:[] ~target:10);
+  "single zero" >::
+    ae (Some [0]) (convert_bases ~from:10 ~digits:[0] ~target:2);
+  "multiple zeros" >::
+    ae (Some [0]) (convert_bases ~from:10 ~digits:[0; 0; 0] ~target:2);
+  "leading zeros" >::
+    ae (Some [4; 2]) (convert_bases ~from:7 ~digits:[0; 0; 6; 0] ~target:10);
+  "negative digit" >::
+    ae None (convert_bases ~from:2 ~digits:[1; -1; 1; 0; 1; 0] ~target:10);
+  "invalid positive digit" >::
+    ae None (convert_bases ~from:2 ~digits:[1; 2; 1; 0; 1; 0] ~target:10);
+  "first base is one" >::
+    ae None (convert_bases ~from:1 ~digits:[] ~target:10);
+  "second base is one" >::
+    ae None (convert_bases ~from:2 ~digits:[1; 0; 1; 0; 1; 0] ~target:1);
+  "first base is zero" >::
+    ae None (convert_bases ~from:0 ~digits:[] ~target:10);
+  "second base is zero" >::
+    ae None (convert_bases ~from:10 ~digits:[7] ~target:0);
+  "first base is negative" >::
+    ae None (convert_bases ~from:(-2) ~digits:[1] ~target:10);
+  "second base is negative" >::
+    ae None (convert_bases ~from:2 ~digits:[1] ~target:(-7));
+  "both bases are negative" >::
+    ae None (convert_bases ~from:(-2) ~digits:[1] ~target:(-7));
+]
+
+let () =
+  run_test_tt_main ("all-your-bases tests" >::: tests)

--- a/tools/test-generator/src/special_cases.ml
+++ b/tools/test-generator/src/special_cases.ml
@@ -8,7 +8,7 @@ let optional_int ~(none: int) = function
   | x -> parameter_to_string x
 
 let optional_int_list = function
-  | IntList xs -> "(Some " ^ String.concat ~sep:"; " (List.map ~f:Int.to_string xs) ^ ")"
+  | IntList xs -> "(Some [" ^ String.concat ~sep:"; " (List.map ~f:Int.to_string xs) ^ "])"
   | _ -> "None"
 
 let optional_int_or_string ~(none: int) = function
@@ -37,7 +37,14 @@ let edit_expected ~(stringify: parameter -> string) ~(slug: string) ~(value: par
 
 let edit_say (ps: (string * string) list) =
   let edit = function
-    | ("input", v) -> ("input", if Int.of_string v < 0 then "(" ^ v ^ "L)" else v ^ "L")
+    | ("input", v) -> ("input", if Int.of_string v >= 0 then "(" ^ v ^ "L)" else v ^ "L")
+    | x -> x in
+  List.map ps ~f:edit
+
+let edit_all_your_base (ps: (string * string) list) =
+  let edit = function
+    | ("output_base", v) -> ("output_base", if Int.of_string v >= 0 then v else "(" ^ v ^ ")")
+    | ("input_base", v) -> ("input_base", if Int.of_string v >= 0 then v else "(" ^ v ^ ")")
     | x -> x in
   List.map ps ~f:edit
 
@@ -46,4 +53,5 @@ let edit_parameters ~(slug: string) (parameters: (string * string) list) = match
     @@ optional_strings ~f:(fun _x -> true)
     @@ parameters
   | ("say", ps) -> edit_say ps
+  | ("all-your-base", ps) -> edit_all_your_base ps
   | (_, ps) -> ps

--- a/tools/test-generator/templates/all-your-base/template.ml
+++ b/tools/test-generator/templates/all-your-base/template.ml
@@ -1,15 +1,19 @@
 open Core.Std
 open OUnit2
-open All_your_bases
+open All_your_base
+
+let option_printer = function
+  | None -> "None"
+  | Some xs -> "Some [" ^ String.concat ~sep:";" (List.map xs ~f:Int.to_string) ^ "]"
 
 let ae exp got _test_ctxt =
-  assert_equal exp got ~printer:Bool.to_string
+  assert_equal exp got ~printer:option_printer
 
 let tests = [
-  (* TEST
-     "$description" >::
-      ae $expected (convert_bases $input_base $input_digits $output_base);
-     END TEST *)
+(* TEST
+  "$description" >::
+    ae $expected (convert_bases ~from:$input_base ~digits:$input_digits ~target:$output_base);
+END TEST *)
 ]
 
 let () =


### PR DESCRIPTION
Added all-your-base, and deprecated hexadecimal.
There is a note in the canonical data leaving it up the language stream on how to interpret lists with leading zeroes, or with just a single zero.
I chose to convert [0] as 0, and to strip leading zeroes.