### PR TITLE
Add robot name

### DIFF
--- a/config.json
+++ b/config.json
@@ -122,6 +122,11 @@
       "topics": []
     },
     {
+      "slug": "robot-name",
+      "difficulty": 6,
+      "topics": ["Randomness", "Mutable state"]
+    },
+    {
       "slug": "list-ops",
       "difficulty": 6,
       "topics": []

--- a/exercises/robot-name/.merlin
+++ b/exercises/robot-name/.merlin
@@ -1,0 +1,3 @@
+S *
+B _build/**
+PKG core oUnit

--- a/exercises/robot-name/Makefile
+++ b/exercises/robot-name/Makefile
@@ -1,0 +1,11 @@
+test: test.native
+	@./test.native
+
+test.native: *.ml *.mli
+	@corebuild -r -quiet -pkg oUnit -pkg re2 test.native
+
+clean:
+	rm -rf _build
+	rm -f test.native
+
+.PHONY: clean

--- a/exercises/robot-name/Makefile
+++ b/exercises/robot-name/Makefile
@@ -2,7 +2,7 @@ test: test.native
 	@./test.native
 
 test.native: *.ml *.mli
-	@corebuild -r -quiet -pkg oUnit -pkg re2 test.native
+	@corebuild -r -quiet -pkg oUnit test.native
 
 clean:
 	rm -rf _build

--- a/exercises/robot-name/example.ml
+++ b/exercises/robot-name/example.ml
@@ -1,0 +1,26 @@
+open Core.Std
+
+type robot = {mutable index : int}
+
+let index = ref (-1)
+
+let unique_ids: int array =
+  let ids = Array.init (26*26*1000) ~f:Fn.id in
+  Array.permute ids;
+  ids
+
+let new_robot () =
+  index := !index + 1;
+  {index = unique_ids.(!index)}
+
+let name r =
+  let n = r.index in
+  let letters_part = n / 1000 in
+  let letter_A = Char.to_int 'A' in
+  let first_letter = Char.of_int_exn (letter_A + (letters_part / 26)) in
+  let second_letter = Char.of_int_exn (letter_A + (letters_part % 26)) in
+  sprintf "%c%c%03d" first_letter second_letter (n % 1000)
+
+let reset r =
+  index := !index + 1;
+  r.index <- unique_ids.(!index);

--- a/exercises/robot-name/robot_name.mli
+++ b/exercises/robot-name/robot_name.mli
@@ -1,0 +1,7 @@
+type robot
+
+val new_robot : unit -> robot
+
+val name : robot -> string
+
+val reset : robot -> unit

--- a/exercises/robot-name/test.ml
+++ b/exercises/robot-name/test.ml
@@ -39,9 +39,10 @@ Optionally: make this test pass.
 
 There are 26 * 26 * 10 * 10 * 10 = 676,000 possible Robot names.
 This test generates all possible Robot names, and checks that there are
-no duplicates.
+no duplicates. It's harder to make pass than the other tests, so it is left
+as optional.
 
-If you want to do this, uncomment the code in the run_test_tt_main
+To enable it, uncomment the code in the run_test_tt_main
 line at the bottom of this module.
 *)
 let unique_name_tests = [

--- a/exercises/robot-name/test.ml
+++ b/exercises/robot-name/test.ml
@@ -1,0 +1,43 @@
+open Core.Std
+open OUnit2
+open Robot_name
+
+let regex = Re2.Regex.create_exn "[A-Z]{2}\\d{3}$"
+
+let tests = [
+  "a robot has a name of 2 letters followed by 3 numbers" >:: (fun _ctxt ->
+    let n = name (new_robot ()) in
+    assert_bool ("'" ^ n ^ "' does not meet the specification") (Re2.Regex.matches regex n)
+    );
+
+  "resetting a robot's name gives it a different name" >:: (fun _ctxt ->
+    let r = new_robot () in
+    let n1 = name r in
+    reset r;
+    let n2 = name r in
+    assert_bool ("'" ^ n1 ^ "' was repeated") (n1 <> n2)
+    );
+
+  "after reset the robot's name still matches the specification" >:: (fun _ctxt ->
+    let r = new_robot () in
+    reset r;
+    let n = name r in
+    assert_bool ("'" ^ n ^ "' does not meet the specification") (Re2.Regex.matches regex n)
+    );
+
+  "10,000 robots all have different names" >:: (fun _ctxt ->
+    let rs = Array.init 10000 ~f:(fun _ -> new_robot ()) in
+    let (repeated, _) = Array.fold rs ~init:(String.Set.empty, String.Set.empty) ~f:(fun (repeated, seen) r ->
+      let n = name r in
+      if Set.mem seen n
+      then (Set.add repeated n, seen)
+      else (repeated, Set.add seen n)
+      ) in
+    let first_few_repeats = Array.slice (Set.to_array repeated) 0 (min 20 (Set.length repeated)) in
+    let failure_message = "first few repeats: " ^ (String.concat_array first_few_repeats ~sep:",") in
+    assert_bool failure_message (Set.is_empty repeated)
+    );
+]
+
+let () =
+  run_test_tt_main ("robot-name tests" >::: tests)

--- a/exercises/robot-name/test.ml
+++ b/exercises/robot-name/test.ml
@@ -2,12 +2,20 @@ open Core.Std
 open OUnit2
 open Robot_name
 
-let regex = Re2.Regex.create_exn "[A-Z]{2}\\d{3}$"
+let assert_matches_spec name =
+  let is_valid_letter ch = 'A' <= ch && ch <= 'Z' in
+  let is_valid_digit ch = '0' <= ch && ch <= '9' in
+  assert_equal ~printer:Int.to_string 5 (String.length name);
+  assert_bool ("First character must be from A to Z") (is_valid_letter @@ name.[0]);
+  assert_bool ("Second character must be from A to Z") (is_valid_letter @@ name.[1]);
+  assert_bool ("Third character must be from 0 to 9") (is_valid_digit @@ name.[2]);
+  assert_bool ("Fourth character must be from 0 to 9") (is_valid_digit @@ name.[3]);
+  assert_bool ("Fifth character must be from 0 to 9") (is_valid_digit @@ name.[4]);;
 
 let basic_tests = [
   "a robot has a name of 2 letters followed by 3 numbers" >:: (fun _ctxt ->
     let n = name (new_robot ()) in
-    assert_bool ("'" ^ n ^ "' does not meet the specification") (Re2.Regex.matches regex n)
+    assert_matches_spec n
     );
 
   "resetting a robot's name gives it a different name" >:: (fun _ctxt ->
@@ -22,7 +30,7 @@ let basic_tests = [
     let r = new_robot () in
     reset r;
     let n = name r in
-    assert_bool ("'" ^ n ^ "' does not meet the specification") (Re2.Regex.matches regex n)
+    assert_matches_spec n
     );
 ]
 

--- a/exercises/robot-name/test.ml
+++ b/exercises/robot-name/test.ml
@@ -4,7 +4,7 @@ open Robot_name
 
 let regex = Re2.Regex.create_exn "[A-Z]{2}\\d{3}$"
 
-let tests = [
+let basic_tests = [
   "a robot has a name of 2 letters followed by 3 numbers" >:: (fun _ctxt ->
     let n = name (new_robot ()) in
     assert_bool ("'" ^ n ^ "' does not meet the specification") (Re2.Regex.matches regex n)
@@ -24,9 +24,21 @@ let tests = [
     let n = name r in
     assert_bool ("'" ^ n ^ "' does not meet the specification") (Re2.Regex.matches regex n)
     );
+]
 
-  "10,000 robots all have different names" >:: (fun _ctxt ->
-    let rs = Array.init 10000 ~f:(fun _ -> new_robot ()) in
+(*
+Optionally: make this test pass.
+
+There are 26 * 26 * 10 * 10 * 10 = 676,000 possible Robot names.
+This test generates all possible Robot names, and checks that there are
+no duplicates.
+
+If you want to do this, uncomment the code in the run_test_tt_main
+line at the bottom of this module.
+*)
+let unique_name_tests = [
+  "all possible robot names are distinct" >:: (fun _ctxt ->
+    let rs = Array.init (26 * 26 * 1000) ~f:(fun _ -> new_robot ()) in
     let (repeated, _) = Array.fold rs ~init:(String.Set.empty, String.Set.empty) ~f:(fun (repeated, seen) r ->
       let n = name r in
       if Set.mem seen n
@@ -40,4 +52,4 @@ let tests = [
 ]
 
 let () =
-  run_test_tt_main ("robot-name tests" >::: tests)
+  run_test_tt_main ("robot-name tests" >::: List.concat [basic_tests (* ; unique_name_tests *)])


### PR DESCRIPTION
I think this is a useful exercise to add, as it _requires_ mutable state for its solution. No other exercise I've seen does this.

This could be made an easier/less challenging exercise by removing the enforcing of unique names (the final test). It would still let learners find out about mutable state & randomness. 

What do you think?