### PR TITLE
Add template for Luhn

### DIFF
--- a/tools/test-generator/src/controller.ml
+++ b/tools/test-generator/src/controller.ml
@@ -28,7 +28,7 @@ let generate_code ~(slug: string) ~(template_file: content) ~(canonical_data_fil
   let fill_in_template = fill_in_template edit_expected edit_parameters in
   let open Result.Monad_infix in
   Result.of_option template ("cannot recognize file for " ^ slug ^ " as a template") >>= fun template ->
-  parse_json_text canonical_data_file (expected_key_name slug)
+  parse_json_text canonical_data_file (expected_key_name slug) (cases_name slug)
   |> Result.map_error ~f:show_error >>= (function
       | Single cases ->
         fill_in_template template.template slug cases
@@ -60,7 +60,7 @@ let check_canonical_data canonical_data_folder =
   let canonical_data_files = List.sort canonical_data_files ~cmp:(fun (s1, _) (s2, _) -> String.compare s1 s2) in
   let total_count = List.length canonical_data_files in
   List.iter canonical_data_files ~f:(fun (slug, text) ->
-    match parse_json_text text (expected_key_name slug) with
+    match parse_json_text text (expected_key_name slug) (cases_name slug) with
     | Error e -> print_endline @@ slug ^ ": " ^ (show_error e)
     | _ -> ok_count := !ok_count + 1
   );

--- a/tools/test-generator/src/special_cases.ml
+++ b/tools/test-generator/src/special_cases.ml
@@ -59,3 +59,7 @@ let edit_parameters ~(slug: string) (parameters: (string * string) list) = match
 let expected_key_name slug = match slug with
 | "dominoes" -> "can_chain"
 | _ -> "expected"
+
+let cases_name slug = match slug with
+| "luhn" -> "valid"
+| _ -> "cases"

--- a/tools/test-generator/templates/luhn/template.ml
+++ b/tools/test-generator/templates/luhn/template.ml
@@ -1,0 +1,16 @@
+open Core.Std
+open OUnit2
+open Luhn
+
+let assert_valid expected input _test_ctxt = 
+  assert_equal ~printer:Bool.to_string expected (valid input)
+
+let tests = [
+(* TEST
+  "$description" >::
+    assert_valid $expected "$input";
+END TEST *)
+]
+
+let () =
+  run_test_tt_main ("luhn tests" >::: tests)

--- a/tools/test-generator/test/parser_test.ml
+++ b/tools/test-generator/test/parser_test.ml
@@ -12,11 +12,11 @@ let ae exp got _test_ctxt = assert_equal exp got ~printer:show_cases
 
 let single x = Ok (Single x)
 
-let call_parser json = parse_json_text json "expected"
+let call_parser json = parse_json_text json "expected" "cases"
 
 let parser_tests = [
   "parses empty json as empty list" >::
-    ae (single []) (call_parser "{\"cases\" : []}");
+    ae (single []) (parse_json_text "{\"test-cases\" : []}" "expected" "test-cases");
 
   "gives an error with a json map that does not have the key cases in" >::
     ae (Error (TestMustHaveKeyCalledCases "case"))


### PR DESCRIPTION
Add some special casing here - the canonical data has
a root key of "valid", rather than the more usual "cases".