### PR TITLE
dominoes: Check that last can match first; Check that output dominoes = input dominoes

### DIFF
--- a/exercises/dominoes/test.ml
+++ b/exercises/dominoes/test.ml
@@ -4,13 +4,19 @@ open Dominoes
 
 let print_dominoe (d1, d2) = sprintf "(%d,%d)" d1 d2
 
+let dominoes_printer xs = "[" ^ String.concat ~sep:";" (List.map xs ~f:print_dominoe) ^ "]"
 let option_printer = function
   | None -> "None"
-  | Some xs -> "Some [" ^ String.concat ~sep:";" (List.map xs ~f:print_dominoe) ^ "]"
+  | Some xs -> "Some " ^ dominoes_printer xs
 
 let rotate_1 xs = List.tl_exn xs @ [List.hd_exn xs]
 
-let check_chain (chained: dominoe list) = 
+let norm l =
+  let norm1 (x, y) = if x > y then (y, x) else (x, y) in
+  List.map ~f:norm1 l |> List.sort ~cmp:compare
+
+let check_chain (input: dominoe list) (chained: dominoe list) =
+  assert_equal (norm input) (norm chained) ~printer:dominoes_printer ~msg:"chain doesn't use the same dominoes as the input";
   let assert_dominoes_match d1 d2 =
     if snd d1 <> fst d2 then failwith @@ sprintf "%s and %s cannot be chained together" (print_dominoe d1) (print_dominoe d2) else () in
   let consecutives = List.zip_exn chained (rotate_1 chained) in
@@ -21,7 +27,7 @@ let assert_empty c = if List.is_empty c then () else failwith "Expected 0 length
 let assert_valid_chain input _ctxt =
   match chain input with
   | None -> failwith "Expecting a chain"
-  | Some(c) -> (if List.is_empty input then assert_empty else check_chain) c  
+  | Some(c) -> (if List.is_empty input then assert_empty else check_chain input) c
 
 let assert_no_chain input _ctxt =
   assert_equal None (chain input) ~printer:option_printer

--- a/exercises/dominoes/test.ml
+++ b/exercises/dominoes/test.ml
@@ -8,12 +8,12 @@ let option_printer = function
   | None -> "None"
   | Some xs -> "Some [" ^ String.concat ~sep:";" (List.map xs ~f:print_dominoe) ^ "]"
 
-let drop_1_right xs = List.rev xs |> List.tl_exn |> List.rev
+let rotate_1 xs = List.tl_exn xs @ [List.hd_exn xs]
 
 let check_chain (chained: dominoe list) = 
   let assert_dominoes_match d1 d2 =
     if snd d1 <> fst d2 then failwith @@ sprintf "%s and %s cannot be chained together" (print_dominoe d1) (print_dominoe d2) else () in
-  let consecutives = List.zip_exn (drop_1_right chained) (List.tl_exn chained) in
+  let consecutives = List.zip_exn chained (rotate_1 chained) in
   List.iter consecutives ~f:(fun (d1, d2) -> assert_dominoes_match d1 d2)
 
 let assert_empty c = if List.is_empty c then () else failwith "Expected 0 length chain"


### PR DESCRIPTION
Closes #139 

More detail in individual commit messages.

Sidebar: It could be the case that only the last commit is necessary - is there an input and output pair for which the consecutive-dominoes check and same-dominoes check hold, but the dominoes-at-ends check doesn't hold? Can't think of one. Nevertheless, I include the commit for completeness.