### PR TITLE
Understand new x common schema

### DIFF
--- a/exercises/run-length-encoding/test.ml
+++ b/exercises/run-length-encoding/test.ml
@@ -13,6 +13,10 @@ let encode_tests = [
      ae "2A3B4C" (encode "AABBBCCCC");
    "single characters mixed with repeated characters" >::
      ae "12WB12W3B24WB" (encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB");
+   "multiple whitespace mixed in string" >::
+     ae "2 hs2q q2w2 " (encode "  hsqq qww  ");
+   "lowercase characters" >::
+     ae "2a3b4c" (encode "aabbbcccc");
 ]
 
 let decode_tests = [
@@ -24,11 +28,15 @@ let decode_tests = [
      ae "AABBBCCCC" (decode "2A3B4C");
    "single characters with repeated characters" >::
      ae "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB" (decode "12WB12W3B24WB");
+   "multiple whitespace mixed in string" >::
+     ae "  hsqq qww  " (decode "2 hs2q q2w2 ");
+   "lower case string" >::
+     ae "aabbbcccc" (decode "2a3b4c");
 ]
 
 let consistency_tests = [
    "encode followed by decode gives original string" >::
-     ae "zzz ZZ  zZ" (decode (encode "zzz ZZ  zZ"));
+     ae "zzz ZZ  zZ" (decode "zzz ZZ  zZ");
 ]
 
 let () =

--- a/tools/test-generator/src/parser.ml
+++ b/tools/test-generator/src/parser.ml
@@ -35,7 +35,7 @@ let parse_single (text: string) (expected_key: string) (cases_key: string): (tes
   Result.return (Single ts)
 
 let is_suite (json: json) (cases_key: string) =
-  let ignorable_keys = ["exercise"; "version"; "methods"] in
+  let ignorable_keys = ["exercise"; "version"; "methods"; "comments"] in
   let keys = List.filter (keys json) ~f:(Fn.non (List.mem ignorable_keys)) in
   let keys = List.sort keys ~cmp:String.compare in
   not (List.is_empty keys || keys = [cases_key] || keys = ["#"; cases_key])

--- a/tools/test-generator/src/special_cases.ml
+++ b/tools/test-generator/src/special_cases.ml
@@ -38,11 +38,22 @@ let option_of_null (value: json): string = match value with
 | `String s -> "(Some \"" ^ s ^ "\")"
 | _ -> failwith "cannot handle this type"
 
+let is_empty_string (value: json): bool = match value with
+| `String s -> String.is_empty s
+| _ -> false
+
+let edit_connect_expected = function
+| `String "X" -> "(Some X)"
+| `String "O" -> "(Some O)"
+| `String "" -> "None"
+| x -> failwith "Bad json value in connect " ^ json_to_string x
+
 let edit_expected ~(stringify: json -> string) ~(slug: string) ~(value: json) = match slug with
 | "hamming" -> optional_int ~none:(-1) value
 | "all-your-base" -> optional_int_list value
 | "say" -> optional_int_or_string ~none:(-1) value
 | "phone-number" -> option_of_null value
+| "connect" -> edit_connect_expected value
 | _ -> stringify value
 
 let edit_say (ps: (string * json) list) =
@@ -58,11 +69,10 @@ let edit_all_your_base (ps: (string * json) list): (string * string) list =
   | (k, v) -> (k, json_to_string v) in
   List.map ps ~f:edit
 
-let two_elt_list_to_tuple (j: json): string = match j with
-| `List [`Int x1; `Int x2] -> sprintf "(%d,%d)" x1 x2
-| _ -> failwith "two element list expected, but got " ^ (json_to_string j)
- 
 let edit_dominoes (ps: (string * json) list): (string * string) list =
+  let two_elt_list_to_tuple (j: json): string = match j with
+  | `List [`Int x1; `Int x2] -> sprintf "(%d,%d)" x1 x2
+  | _ -> failwith "two element list expected, but got " ^ (json_to_string j) in 
   let edit (p: (string * json)) = match p with
   | ("input", `List j) -> ("input", "[" ^ (List.map ~f:two_elt_list_to_tuple j |> String.concat ~sep:"; ") ^ "]")
   | (k, v) -> (k, json_to_string v) in
@@ -79,6 +89,4 @@ let expected_key_name slug = match slug with
 | "dominoes" -> "can_chain"
 | _ -> "expected"
 
-let cases_name slug = match slug with
-| "luhn" -> "valid"
-| _ -> "cases"
+let cases_name _slug = "cases"


### PR DESCRIPTION
All but 1 of the existing templates can be re-generated.
atbash-cipher uses a group test which is not coded for yet.