### PR TITLE
Fix typo in triangle and use floats

### DIFF
--- a/exercises/triangle/example.ml
+++ b/exercises/triangle/example.ml
@@ -1,15 +1,15 @@
 open Core.Std
 
 let sort_sides a b c = 
-  let side = List.nth_exn (List.sort ~cmp:Int.compare [a; b; c]) in
+  let side = List.nth_exn (List.sort ~cmp:Float.compare [a; b; c]) in
   (side 0, side 1, side 2)
 
 let is_triangle a b c = 
   let (a, b, c) = sort_sides a b c in
-  c > 0 && c <= a + b
+  c > 0. && c <= a +. b
 
 let is_equilateral a b c = is_triangle a b c && a = b && b = c
 
-let is_isoceles a b c = is_triangle a b c && (a = b || b = c || a = c)
+let is_isosceles a b c = is_triangle a b c && (a = b || b = c || a = c)
 
 let is_scalene a b c = is_triangle a b c && (a <> b && b <> c)

--- a/exercises/triangle/test.ml
+++ b/exercises/triangle/test.ml
@@ -5,44 +5,50 @@ open Triangle
 let ae exp got _test_ctxt = assert_equal exp got ~printer:Bool.to_string
 
 let equilateral_tests = [
-   "true if all sides are equal" >::
-     ae true (is_equilateral 2 2 2);
-   "false if any side is unequal" >::
-     ae false (is_equilateral 2 3 2);
-   "false if no sides are equal" >::
-     ae false (is_equilateral 5 4 6);
-   "All zero sides are illegal, so the triangle is not equilateral" >::
-     ae false (is_equilateral 0 0 0);
+  "true if all sides are equal" >::
+    ae true (is_equilateral 2. 2. 2.);
+  "false if any side is unequal" >::
+    ae false (is_equilateral 2. 3. 2.);
+  "false if no sides are equal" >::
+    ae false (is_equilateral 5. 4. 6.);
+  "All zero sides are illegal, so the triangle is not equilateral" >::
+    ae false (is_equilateral 0. 0. 0.);
+  "sides may be floats" >::
+    ae true (is_equilateral 0.5 0.5 0.5);
 ]
 
-let isoceles_tests = [
-   "true if last two sides are equal" >::
-     ae true (is_isoceles 3 4 4);
-   "true if first two sides are equal" >::
-     ae true (is_isoceles 4 4 3);
-   "true if first and last sides are equal" >::
-     ae true (is_isoceles 4 3 4);
-   "equilateral triangles are also isosceles" >::
-     ae true (is_isoceles 4 4 4);
-   "false if no sides are equal" >::
-     ae false (is_isoceles 2 3 4);
-   "Sides that violate triangle inequality are not isosceles, even if two are equal" >::
-     ae false (is_isoceles 1 1 3);
-]
+let isosceles_tests = [
+  "true if last two sides are equal" >::
+    ae true (is_isosceles 3. 4. 4.);
+  "true if first two sides are equal" >::
+    ae true (is_isosceles 4. 4. 3.);
+  "true if first and last sides are equal" >::
+    ae true (is_isosceles 4. 3. 4.);
+  "equilateral triangles are also isosceles" >::
+    ae true (is_isosceles 4. 4. 4.);
+  "false if no sides are equal" >::
+    ae false (is_isosceles 2. 3. 4.);
+  "Sides that violate triangle inequality are not isosceles, even if two are equal" >::
+    ae false (is_isosceles 1. 1. 3.);
+  "sides may be floats" >::
+    ae true (is_isosceles 0.5 0.4 0.5);
+  ]
 
 let scalene_tests = [
-   "true if no sides are equal" >::
-     ae true (is_scalene 5 4 6);
-   "false if all sides are equal" >::
-     ae false (is_scalene 4 4 4);
-   "false if two sides are equal" >::
-     ae false (is_scalene 4 4 3);
-   "Sides that violate triangle inequality are not scalene, even if they are all different" >::
-     ae false (is_scalene 7 3 2);
-]
+  "true if no sides are equal" >::
+    ae true (is_scalene 5. 4. 6.);
+  "false if all sides are equal" >::
+    ae false (is_scalene 4. 4. 4.);
+  "false if two sides are equal" >::
+    ae false (is_scalene 4. 4. 3.);
+  "Sides that violate triangle inequality are not scalene, even if they are all different" >::
+    ae false (is_scalene 7. 3. 2.);
+  "sides may be floats" >::
+    ae true (is_scalene 0.5 0.4 0.6);
+  ]
 
 let () =
   run_test_tt_main (
     "triangle tests" >:::
-      List.concat [equilateral_tests; isoceles_tests; scalene_tests]
+      List.concat [equilateral_tests; isosceles_tests; scalene_tests]
   )

--- a/exercises/triangle/triangle.mli
+++ b/exercises/triangle/triangle.mli
@@ -1,5 +1,5 @@
-val is_equilateral : int -> int -> int -> bool
+val is_equilateral : float -> float -> float -> bool
 
-val is_isoceles : int -> int -> int -> bool
+val is_isosceles : float -> float -> float -> bool
 
-val is_scalene : int -> int -> int -> bool
+val is_scalene : float -> float -> float -> bool

--- a/tools/test-generator/templates/triangle/template.ml
+++ b/tools/test-generator/templates/triangle/template.ml
@@ -11,10 +11,10 @@ let (* SUITE returns_true_if_the_triangle_is_equilateral *)equilateral_tests = [
    END TEST *)
 ]
 (* END SUITE *)
-let (* SUITE returns_true_if_the_triangle_is_isosceles *)isoceles_tests = [
+let (* SUITE returns_true_if_the_triangle_is_isosceles *)isosceles_tests = [
 (* TEST
    "$description" >::
-     ae $expected (is_isoceles $sides);
+     ae $expected (is_isosceles $sides);
    END TEST *)
 ]
 (* END SUITE *)
@@ -29,5 +29,5 @@ let (* SUITE returns_true_if_the_triangle_is_scalene *)scalene_tests = [
 let () =
   run_test_tt_main (
     "triangle tests" >:::
-      List.concat [equilateral_tests; isoceles_tests; scalene_tests]
+      List.concat [equilateral_tests; isosceles_tests; scalene_tests]
   )


### PR DESCRIPTION
is_isosceles was spelt wrongly.
Canonical data now uses floats for sides, so changing
to match that.