### PR TITLE
Remove license info from README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+Copyright (c) 2017 Exercism, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -62,11 +62,6 @@ is documentation [here](tools/test-generator/README.md).
 
 If you find this documentation is inaccurate or incomplete, or can be improved in any way, please don't hesitate to raise an [issue](https://github.com/exercism/xocaml/issues) or submit a pull request.
 
-## License
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
 
 ### OCaml icon
 The [OCaml](https://ocaml.org) logo is released under the [Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/) license.


### PR DESCRIPTION
We don't need the duplication, especially now that the GitHub interface shows the
license information on the main page of the repository when it can be detected
directly from the LICENSE file.

This also updates the license file to reassign copyright to the Exercism legal entity.